### PR TITLE
Add critical cache cleanup functionality to prevent user data mixing

### DIFF
--- a/modules/layout.py
+++ b/modules/layout.py
@@ -1076,6 +1076,13 @@ def create_settings_page():
                         className="me-2",
                         style={'backgroundColor': '#f39c12', 'borderColor': '#f39c12', 'color': SPOTIFY_BLACK}
                     ),
+                    dbc.Button(
+                        "🧹 Clear Cache Files (Critical)",
+                        id="clear-cache-button",
+                        color="danger",
+                        className="me-2",
+                        style={'backgroundColor': '#e74c3c', 'borderColor': '#e74c3c', 'color': SPOTIFY_WHITE}
+                    ),
                     html.Div(id='update-credentials-status', className='mt-3', style={'color': SPOTIFY_WHITE})
                 ])
             ], style={'backgroundColor': '#181818', 'border': '1px solid #282828', 'marginBottom': '30px'}),


### PR DESCRIPTION
- Add cache file removal to deployment startup cleanup function
- Create new "Clear Cache Files" button in settings with critical warning
- Implement cache clearing callback to remove Spotify auth tokens and temp files
- Update cleanup messaging to reflect both database and cache operations